### PR TITLE
Do not report unavailable values as NaN

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -347,7 +347,7 @@ func splitSensorOutput(impitoolOutput string) ([]sensorData, error) {
 			} else if valueS != "na" && convErr == nil {
 				data.Value = float64(convValueS)
 			} else {
-				data.Value = math.NaN()
+				continue
 			}
 			data.Type = splittedL[2]
 			data.State = splittedL[3]


### PR DESCRIPTION
I am currently creating a Grafana dashboard for the ipmi exporter. And I find it incredibly difficult to deal with the returned NaN values. For example, I want to calculate the average power consumption. But when a node is powered off, the power consumption is reported as NaN. Hence the entire calculated power consumption result becomes NaN at some point. My attempt to join the query with `ipmi_power_state` and to assume a default value instead of NaN while the node is powered off have been futile. In Prometheus, it is good practice to skip missing values. Doing so would allow a simple `or` in the Prometheus query to be used to deal with the missing values appropriately. So, please consider to simply skip unavailable values rather than reporting them as NaN.